### PR TITLE
Comprehensive tests: all 4 models × all endpoints, navigation, TESTING.md

### DIFF
--- a/web/templates/navigation.html
+++ b/web/templates/navigation.html
@@ -86,14 +86,20 @@
 	  </ul>
 	  <!-- Search Forms -->
 	  <form class="d-flex" role="search" action="{{ url_for('namae') }}" method="get">
-	      <input class="form-control me-2" type="search" name="orth" placeholder="書き方" aria-label="書き方"  style="width: 100px;">
-	      <input class="form-control me-2" type="search" name="pron" placeholder="読み方" aria-label="読み方"  style="width: 100px;">
+	    {% if db_supports_orth %}
+	      <input class="form-control me-2" type="search" name="orth" placeholder="書き方" aria-label="書き方" style="width: 100px;">
+	    {% endif %}
+	    {% if db_supports_pron %}
+	      <input class="form-control me-2" type="search" name="pron" placeholder="読み方" aria-label="読み方" style="width: 100px;">
+	    {% endif %}
 	      <button class="btn btn-outline-success" type="submit">🔍</button>
 	  </form>
+	  {% if db_supports_kanji %}
 	  <form class="d-flex" role="search" action="{{ url_for('kanji') }}" method="get">
-  	    <input class="form-control me-2" type="search" name="kanji" placeholder="漢字" aria-label="漢字" style="width: 80px;">
-  	    <button class="btn btn-outline-primary" type="submit">🔍</button>
-  	  </form>
+	    <input class="form-control me-2" type="search" name="kanji" placeholder="漢字" aria-label="漢字" style="width: 80px;">
+	    <button class="btn btn-outline-primary" type="submit">🔍</button>
+	  </form>
+	  {% endif %}
   
 	  
 	  <ul class="navbar-nav ms-auto mb-2 mb-lg-0">


### PR DESCRIPTION
## Summary

- Add ~170 new tests covering all 4 database models (bc, hs, meiji, meiji_p) × every route
- Test orth/pron/kanji searches on models that support them; verify graceful failure on unsupported models
- Add `DB_CAPS` dict and `_switch_db()` helper for parametrized model tests
- Mark slow cross-model tests with `@pytest.mark.slow` (skipped by default; run with `-m slow`)
- Remove `xfail` from `TestProportion` (page now exists)
- Rewrite `TESTING.md`: test structure, timing (~45s fast / ~60s full), route coverage map, "where to add tests" guide

## Test plan

- [ ] `pytest tests/ -v` — all non-slow tests pass (~45s)
- [ ] `pytest tests/ -v -m slow` — all slow cross-model tests pass (~60s additional)
- [ ] Confirm `TestProportion.test_proportion_page` passes (no longer xfail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)